### PR TITLE
Add WebTrajectoryCapture scaffold

### DIFF
--- a/apps/webtrajectorycapture/LICENSE
+++ b/apps/webtrajectorycapture/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Sideguide Technologies Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/webtrajectorycapture/README.md
+++ b/apps/webtrajectorycapture/README.md
@@ -1,0 +1,8 @@
+# WebTrajectoryCapture
+
+This project demonstrates how to record browser interactions with Playwright and store them as JSONL alongside screenshots and DOM dumps.
+
+The **server** folder contains a simple Express app with a stubbed recorder. The **client** folder is intended for a React QA console.
+
+## Sample
+A minimal trajectory is provided in `sample_data/trajectory.jsonl`.

--- a/apps/webtrajectorycapture/client/index.html
+++ b/apps/webtrajectorycapture/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Web Trajectory QA</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/webtrajectorycapture/client/package.json
+++ b/apps/webtrajectorycapture/client/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "web-trajectory-capture-client",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "typescript": "^5.4.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/apps/webtrajectorycapture/client/src/App.tsx
+++ b/apps/webtrajectorycapture/client/src/App.tsx
@@ -1,0 +1,8 @@
+export function App() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">QA Console</h1>
+      <p>Timeline and diff view will appear here.</p>
+    </div>
+  );
+}

--- a/apps/webtrajectorycapture/client/src/main.tsx
+++ b/apps/webtrajectorycapture/client/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/webtrajectorycapture/client/tsconfig.json
+++ b/apps/webtrajectorycapture/client/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/apps/webtrajectorycapture/client/vite.config.ts
+++ b/apps/webtrajectorycapture/client/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});

--- a/apps/webtrajectorycapture/sample_data/trajectory.jsonl
+++ b/apps/webtrajectorycapture/sample_data/trajectory.jsonl
@@ -1,0 +1,1 @@
+{"step":0,"timestamp":"2025-06-18T12:34:56.789Z","action":{"type":"NAVIGATE","url":"https://example.com"},"screenshot":"session_0/0000.png","dom":"session_0/0000.html","url":"https://example.com"}

--- a/apps/webtrajectorycapture/server/README.md
+++ b/apps/webtrajectorycapture/server/README.md
@@ -1,0 +1,3 @@
+# WebTrajectoryCapture Server
+
+A basic Express server with a stubbed Playwright recorder. POST `/api/session` with `{ "url": "https://example.com" }` to generate a simple trajectory in the `data/` folder.

--- a/apps/webtrajectorycapture/server/package.json
+++ b/apps/webtrajectorycapture/server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "web-trajectory-capture-server",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "ts-node src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "playwright": "^1.45.0",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.14.9",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.2"
+  }
+}

--- a/apps/webtrajectorycapture/server/src/index.ts
+++ b/apps/webtrajectorycapture/server/src/index.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import { startRecording } from './recorder';
+
+const app = express();
+app.use(express.json());
+
+app.post('/api/session', async (req, res) => {
+  const { url } = req.body;
+  const id = uuidv4();
+  await startRecording(id, url); // stubbed
+  res.json({ id });
+});
+
+const port = process.env.PORT || 4000;
+app.listen(port, () => {
+  console.log(`Server listening on ${port}`);
+});

--- a/apps/webtrajectorycapture/server/src/recorder.ts
+++ b/apps/webtrajectorycapture/server/src/recorder.ts
@@ -1,0 +1,28 @@
+import { chromium, Browser, Page } from 'playwright';
+import fs from 'fs';
+import path from 'path';
+
+export async function startRecording(id: string, url: string) {
+  // This is a simplified stub that launches a browser and takes one screenshot
+  const dir = path.join('data', id);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const browser: Browser = await chromium.launch();
+  const page: Page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+  await page.goto(url);
+
+  // Example of capturing a single step
+  const step = {
+    step: 0,
+    timestamp: new Date().toISOString(),
+    action: { type: 'NAVIGATE', url },
+    screenshot: `${id}/0000.png`,
+    dom: `${id}/0000.html`,
+    url
+  };
+  await page.screenshot({ path: path.join(dir, '0000.png') });
+  fs.writeFileSync(path.join(dir, '0000.html'), await page.content());
+  fs.writeFileSync(path.join(dir, 'trajectory.jsonl'), JSON.stringify(step) + '\n');
+
+  await browser.close();
+}

--- a/apps/webtrajectorycapture/server/tsconfig.json
+++ b/apps/webtrajectorycapture/server/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- scaffold WebTrajectoryCapture project under `apps/`
- add Express server with stub Playwright recorder
- add React client skeleton with Vite config
- include sample trajectory file and MIT license

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852bc7d00e4832fa7b3992971209c5b